### PR TITLE
Enroll yubikey on windows

### DIFF
--- a/Lib/yubico/yubikey_usb_hid.py
+++ b/Lib/yubico/yubikey_usb_hid.py
@@ -27,6 +27,7 @@ import struct
 import time
 import usb
 import sys
+import platform
 
 # Various USB/HID parameters
 _USB_TYPE_CLASS		= (0x01 << 5)
@@ -431,7 +432,8 @@ class YubiKeyUSBHID(YubiKey):
 
         try:
             self._usb_handle = usb_device.open()
-            self._usb_handle.detachKernelDriver(0)
+            if platform.system().lower() == "linux":
+                    self._usb_handle.detachKernelDriver(0)
         except usb.USBError, error:
             if 'could not detach kernel driver from interface' in str(error):
                 self._debug('The in-kernel-HID driver has already been detached\n')
@@ -439,7 +441,8 @@ class YubiKeyUSBHID(YubiKey):
                 raise
 
         self._usb_handle.setConfiguration(1)
-        self._usb_handle.claimInterface(self._usb_int)
+        if platform.system().lower() == "linux":
+            self._usb_handle.claimInterface(self._usb_int)
         return True
 
     def _close(self):


### PR DESCRIPTION
I am using yubikey on Windows with python-usb and the zadig driver tool.

When trying to enroll a yubikey the detachKernelDriver fails, as this does not seem to be available on windows.

So I added a small patch, which enables me, to enroll the yubikey on windows.
