### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -43,7 +43,7 @@ except yubico.yubico_exception.YubicoError as e:
 === Installation
 python-yubico is installable via pip:
 
-  $ pip install yubico-python
+  $ pip install python-yubico
 
 Or, directly from the source package in the standard-python way:
 


### PR DESCRIPTION
Specify the correct package in the `pip install` installation instruction.

The current installation instruction results in the following error:
```Bash
$ pip install yubico-python
Downloading/unpacking yubico-python
  Could not find any downloads that satisfy the requirement yubico-python
Cleaning up...
No distributions at all found for yubico-python
Storing debug log for failure in /home/vlad/.pip/pip.log
```