### PR TITLE
Solved: Unlock code couldn't be set

### DIFF
--- a/yubico/yubikey_frame.py
+++ b/yubico/yubikey_frame.py
@@ -120,6 +120,8 @@ class YubiKeyFrame:
                 return (data, "AAlETCr")
             if yubico_util.ord_byte(data[-1]) == 0x87:
                 return (data, "rCR")
+            if yubico_util.ord_byte(data[-1]) == 0x88:
+                return (data, '')
             # after payload
             if yubico_util.ord_byte(data[-1]) == 0x89:
                 return (data, " Scr")


### PR DESCRIPTION
Unlock code to update/overwrite a password protected configuration
couldn't be set by the library. The problem was solved by adding a if
clause for the configuration-byte with id 0x88 in class YubiKeyFrame in
function _debug_string().