### PR TITLE
Updated README example to Python 3

### DIFF
--- a/README
+++ b/README
@@ -31,9 +31,9 @@ import yubico
 
 try:
     yubikey = yubico.find_yubikey(debug=False)
-    print "Version : %s " % yubikey.version()
+    print("Version: {}".format(yubikey.version()))
 except yubico.yubico_exception.YubicoError as e:
-    print "ERROR: %s" % e.reason
+    print("ERROR: {}".format(e.reason))
     sys.exit(1)
 ----
 
@@ -54,20 +54,13 @@ python-yubico is installable via pip:
 
   $ pip install python-yubico
 
+==== Using Setup
 Or, directly from the source package in the standard Python way:
 
   $ cd python-yubico-$ver
   $ python setup.py install
 
-This requires the `python-setuptools` package. You will also need
-http://walac.github.io/pyusb[PyUSB], called python-usb in Debian/Ubuntu.
-`pyusb` is available on PyPI and may be installed with pip: `pip install --pre
-pyusb`  The --pre command-line option indicates that pre-releases of `pyusb`
-may also be searched (only pre-releases of `pyusb` are available on PyPI, and
-pip skips pre-releases by default). Note that while both the 0.4 branch and the
-1.0 branch are supported, the older 0.4 branch doesn't support re-attaching the
-kernel device driver on close, which will leave the YubiKey in a state where it
-is unable to output OTPs until it has been unplugged and plugged back in again.
+This requires the `python-setuptools` package.
 
 ==== On Windows
 If you use Windows, you will require a PyUSB backend. Python-yubico has been


### PR DESCRIPTION
Updated code example to Python 3 (see https://pythonclock.org/) and removed pre-release PyUSB notes, as the pip/PyPi and the setup install methods will now fetch a recent release of PyUSB. Consider updating https://developers.yubico.com/python-yubico/ as well, as it essentially shows the README document.
