### PR TITLE
Update travis file, drop old and unsupported python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: python
 sudo: false
 
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
   - "pypy"
 
 cache:


### PR DESCRIPTION
Python 2.6 and 3.5 are not downloadable anymore.