### PR TITLE
Do not use comparision with "is" for literals

### DIFF
--- a/yubico/yubikey_config.py
+++ b/yubico/yubikey_config.py
@@ -475,12 +475,12 @@ class YubiKeyConfig(object):
         """
         data = self.to_string()
         payload = data.ljust(64, yubico_util.chr_byte(0x0))
-        if slot is 1:
+        if slot == 1:
             if self._update_config:
                 command = SLOT.UPDATE1
             else:
                 command = SLOT.CONFIG
-        elif slot is 2:
+        elif slot == 2:
             if self._update_config:
                 command = SLOT.UPDATE2
             else:

--- a/yubico/yubikey_usb_hid.py
+++ b/yubico/yubikey_usb_hid.py
@@ -285,13 +285,13 @@ class YubiKeyHIDDevice(object):
                         seconds_left = min(20, seconds_left)
                         wait_num = (seconds_left * 2) - 1 + 6
 
-            if mode is 'nand':
+            if mode == 'nand':
                 if not flags & mask == mask:
                     finished = True
                 else:
                     self._debug("Status %s (0x%x) has not cleared bits %s (0x%x)\n"
                                 % (bin(flags), flags, bin(mask), mask))
-            elif mode is 'and':
+            elif mode == 'and':
                 if flags & mask == mask:
                     finished = True
                 else:
@@ -303,7 +303,7 @@ class YubiKeyHIDDevice(object):
             if not finished:
                 wait_num -= 1
                 if wait_num == 0:
-                    if mode is 'nand':
+                    if mode == 'nand':
                         reason = 'Timed out waiting for YubiKey to clear status 0x%x' % mask
                     else:
                         reason = 'Timed out waiting for YubiKey to set status 0x%x' % mask


### PR DESCRIPTION
There is a warning with python 3.8 at fedora rawhide about
comparision with "is" while running ipa-server install.
See: https://bugs.python.org/issue34850

```/usr/lib/python3.8/site-packages/yubico/yubikey_usb_hid.py:288: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if mode is 'nand':
/usr/lib/python3.8/site-packages/yubico/yubikey_usb_hid.py:294: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif mode is 'and':
/usr/lib/python3.8/site-packages/yubico/yubikey_usb_hid.py:306: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if mode is 'nand':
/usr/lib/python3.8/site-packages/yubico/yubikey_config.py:478: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if slot is 1:
/usr/lib/python3.8/site-packages/yubico/yubikey_config.py:483: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif slot is 2:
```

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>