### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/ykdef.h
+++ b/doc/ykdef.h
@@ -136,7 +136,7 @@ struct config_st {
 /* Yubikey 2 and above */
 #define CFGFLAG_SHORT_TICKET	0x02	/* Send truncated ticket (half length) */
 #define CFGFLAG_STRONG_PW1	0x10	/* Strong password policy flag #1 (mixed case) */
-#define CFGFLAG_STRONG_PW2	0x40	/* Strong password policy flag #2 (subtitute 0..7 to digits) */
+#define CFGFLAG_STRONG_PW2	0x40	/* Strong password policy flag #2 (substitute 0..7 to digits) */
 #define CFGFLAG_MAN_UPDATE	0x80	/* Allow manual (local) update of static OTP */
 
 /* Yubikey 2.1 and above */

--- a/yubico/yubikey_config_util.py
+++ b/yubico/yubikey_config_util.py
@@ -28,7 +28,7 @@ class YubiKeyFlag(object):
         @param value: Bit value, 0x20 for APPEND_CR
         @param doc: Human readable description of flag
         @param min_ykver: Tuple with the minimum version required (major, minor,)
-        @param min_ykver: Tuple with the maximum version required (major, minor,) (for depreacted flags)
+        @param min_ykver: Tuple with the maximum version required (major, minor,) (for deprecated flags)
         @param models: List of model identifiers (strings) that support this flag
         """
         if type(key) is not str:

--- a/yubico/yubikey_neo_usb_hid.py
+++ b/yubico/yubikey_neo_usb_hid.py
@@ -268,7 +268,7 @@ class YubiKeyNEO_NDEF(object):
 
     def _encode_ndef_text_params(self, data):
         """
-        Prepend language and enconding information to data, according to
+        Prepend language and encoding information to data, according to
         nfcforum-ts-rtd-text-1-0.pdf
         """
         status = len(self.ndef_text_lang)


### PR DESCRIPTION
There are small typos in:
- doc/ykdef.h
- yubico/yubikey_config_util.py
- yubico/yubikey_neo_usb_hid.py

Fixes:
- Should read `substitute` rather than `subtitute`.
- Should read `encoding` rather than `enconding`.
- Should read `deprecated` rather than `depreacted`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md