### PR TITLE
Fix python3.9+ issue as it is currently already within Debian/Ubuntu

### DIFF
--- a/util/yubikey-totp
+++ b/util/yubikey-totp
@@ -103,7 +103,7 @@ def make_totp(args):
             print("Serial  : %i" % YK.serial())
         print("")
     # Do challenge-response
-    secret = struct.pack("> Q", args.time / args.step).ljust(64, chr(0x0))
+    secret = struct.pack("> Q", int(args.time / args.step)).ljust(64, bytes.fromhex('00'))
     if args.debug:
         print("Sending challenge : %s\n" % (binascii.hexlify(secret)))
     response = YK.challenge_response(secret, slot=args.slot)


### PR DESCRIPTION
Please fix the Python 3.9+ Compatibility Issue. 

This fix is as shown here already part of the Debian/Ubuntu Package.

I'm perfectly aware that there is already another MR which would fix the same issue. However I think (if nothing speaks against the solution as shown here) it would make sense to stick to a solution which is already shipped by two big distros.

BTW: I'm not the author of this patch - that's Pere Reinholdsen - a fellow Debian Developer.

Greetings
Patrick